### PR TITLE
Initial support for puppetserver 2.0.0 paths

### DIFF
--- a/files/lenses/trapperkeeper.aug
+++ b/files/lenses/trapperkeeper.aug
@@ -117,7 +117,7 @@ let rec entry = hash (entry|simple|array)
 let lns = (empty|comment)* . (entry . (empty|comment)*)*
 
 (* Variable: filter *)
-let filter = incl "/etc/puppetserver/conf.d/*"
+let filter = incl "/etc/puppetserver/conf.d/*" . incl "/etc/puppetlabs/puppetserver/conf.d/*"
            . Util.stdexcl
 
 let xfm = transform lns filter

--- a/manifests/config/puppetserver.pp
+++ b/manifests/config/puppetserver.pp
@@ -4,7 +4,11 @@ define puppetserver::config::puppetserver (
 ) {
   require ::puppetserver::augeas
 
-  $targetdir = '/etc/puppetserver/conf.d'
+  if versioncmp($::puppetversion, '4.0.0') >= 0 {
+    $targetdir = '/etc/puppetlabs/puppetserver/conf.d'
+  } else {
+    $targetdir = '/etc/puppetserver/conf.d'
+  }
   $target = "/files${targetdir}/${name}"
 
   case $ensure {


### PR DESCRIPTION
Puppetserver 2.0.0 uses the path /etc/puppetlabs/puppetserver/* now for its configuration files.
This PR adds support for this.
I'm dislike checking for `$::puppetversion` but there is no fact for the the puppetserver version.
If you have a better way of checking this, I'm happy to hear it.