### PR TITLE
different path for bootstrap.cfg on puppetserver 2.x

### DIFF
--- a/manifests/config/bootstrap.pp
+++ b/manifests/config/bootstrap.pp
@@ -19,9 +19,15 @@ define puppetserver::config::bootstrap (
     }
   }
 
+  if versioncmp($::puppetversion, '4.0.0') >= 0 {
+    $targetfile = '/etc/puppetlabs/puppetserver/bootstrap.cfg'
+  } else {
+    $targetfile = '/etc/puppetserver/bootstrap.cfg'
+  }
+
   augeas { "Set puppetserver bootstrap ${title}":
     lens    => 'Simplelines.lns',
-    incl    => '/etc/puppetserver/bootstrap.cfg',
+    incl    => "${targetfile}",
     changes => $changes,
     onlyif  => $onlyif,
   }

--- a/manifests/config/bootstrap.pp
+++ b/manifests/config/bootstrap.pp
@@ -27,7 +27,7 @@ define puppetserver::config::bootstrap (
 
   augeas { "Set puppetserver bootstrap ${title}":
     lens    => 'Simplelines.lns',
-    incl    => "${targetfile}",
+    incl    => $targetfile,
     changes => $changes,
     onlyif  => $onlyif,
   }


### PR DESCRIPTION
puppetserver 2.x has a different path for bootstrap.cfg