### PR TITLE
Fix puppetlabs-apt version dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "version_requirement": ">=1.0.0 <3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
The current version of puppetlabs-apt is v2.1.1 but this module pins to <2.0.0.
Bump the version to allow it to upgrade.
I've tested this change on a Ubuntu 14.04.2 LTS.