### PR TITLE
added support for a yum proxy and setting the baseurl for yum repositories

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -1,8 +1,26 @@
 class puppetserver::repository (
-  $yum_proxy          = undef,
-  $yum_proxy_username = undef,
-  $yum_proxy_password = undef,
+  $yum_proxy            = undef,
+  $yum_proxy_username   = undef,
+  $yum_proxy_password   = undef,
+  $yum_deps_baseurl     = undef,
+  $yum_products_baseurl = undef,
   ){
+
+
+  if $yum_deps_baseurl {
+    $yum_real_deps_baseurl = $yum_deps_baseurl
+  }
+  else {
+    $yum_real_deps_baseurl = "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/dependencies/\$basearch"
+  }
+
+  if $yum_products_baseurl {
+    $yum_real_products_baseurl = $yum_products_baseurl
+  }
+  else {
+    $yum_real_products_baseurl = "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/products/\$basearch"
+  }
+
   case $::osfamily {
     'Debian': {
       include ::apt
@@ -16,7 +34,7 @@ class puppetserver::repository (
     'RedHat': {
       yumrepo { 'puppetlabs-deps':
         descr          => "Puppet Labs Dependencies El ${::operatingsystemmajrelease} - \$basearch",
-        baseurl        => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/dependencies/\$basearch",
+        baseurl        => $yum_real_deps_baseurl,
         gpgcheck       => '1',
         gpgkey         => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
         enabled        => '1',
@@ -26,7 +44,7 @@ class puppetserver::repository (
       }
       yumrepo { 'puppetlabs-products':
         descr          => "Puppet Labs Products El ${::operatingsystemmajrelease} - \$basearch",
-        baseurl        => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/products/\$basearch",
+        baseurl        => $yum_real_products_baseurl,
         gpgcheck       => '1',
         gpgkey         => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
         enabled        => '1',

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -1,4 +1,8 @@
-class puppetserver::repository {
+class puppetserver::repository (
+  $yum_proxy          = undef,
+  $yum_proxy_username = undef,
+  $yum_proxy_password = undef,
+  ){
   case $::osfamily {
     'Debian': {
       include ::apt
@@ -11,18 +15,24 @@ class puppetserver::repository {
     }
     'RedHat': {
       yumrepo { 'puppetlabs-deps':
-        descr    => "Puppet Labs Dependencies El ${::operatingsystemmajrelease} - \$basearch",
-        baseurl  => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/dependencies/\$basearch",
-        gpgcheck => '1',
-        gpgkey   => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
-        enabled  => '1',
+        descr          => "Puppet Labs Dependencies El ${::operatingsystemmajrelease} - \$basearch",
+        baseurl        => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/dependencies/\$basearch",
+        gpgcheck       => '1',
+        gpgkey         => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
+        enabled        => '1',
+        proxy          => $yum_proxy,
+        proxy_username => $yum_proxy_username,
+        proxy_password => $yum_proxy_password,
       }
       yumrepo { 'puppetlabs-products':
-        descr    => "Puppet Labs Products El ${::operatingsystemmajrelease} - \$basearch",
-        baseurl  => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/products/\$basearch",
-        gpgcheck => '1',
-        gpgkey   => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
-        enabled  => '1',
+        descr          => "Puppet Labs Products El ${::operatingsystemmajrelease} - \$basearch",
+        baseurl        => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/products/\$basearch",
+        gpgcheck       => '1',
+        gpgkey         => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
+        enabled        => '1',
+        proxy          => $yum_proxy,
+        proxy_username => $yum_proxy_username,
+        proxy_password => $yum_proxy_password,
       }
     }
     default: {

--- a/spec/classes/puppetserver__repository_spec.rb
+++ b/spec/classes/puppetserver__repository_spec.rb
@@ -12,6 +12,36 @@ describe 'puppetserver::repository' do
         it { should compile.with_all_deps }
         it { should contain_class('puppetserver::repository') }
       end
+
+      case facts[:osfamily]
+      when 'RedHat'
+        context 'on redhat without proxy parameters set' do
+          it { should contain_yumrepo('puppetlabs-deps').without_proxy }
+          it { should contain_yumrepo('puppetlabs-deps').without_proxy_username }
+          it { should contain_yumrepo('puppetlabs-deps').without_proxy_password }
+
+          it { should contain_yumrepo('puppetlabs-products').without_proxy }
+          it { should contain_yumrepo('puppetlabs-products').without_proxy_username }
+          it { should contain_yumrepo('puppetlabs-products').without_proxy_password }
+        end
+
+        context 'on redhat with proxy parameters set' do
+          let(:params) do
+            {
+              :yum_proxy => 'http://proxy:8080/',
+              :yum_proxy_username => 'user',
+              :yum_proxy_password => 'password',
+            }
+          end
+          it { should contain_yumrepo('puppetlabs-deps').with({ 'proxy' => 'http://proxy:8080/' }) }
+          it { should contain_yumrepo('puppetlabs-deps').with({ 'proxy_username' => 'user' }) }
+          it { should contain_yumrepo('puppetlabs-deps').with({ 'proxy_password' => 'password' }) }
+
+          it { should contain_yumrepo('puppetlabs-products').with({ 'proxy' => 'http://proxy:8080/' }) }
+          it { should contain_yumrepo('puppetlabs-products').with({ 'proxy_username' => 'user' }) }
+          it { should contain_yumrepo('puppetlabs-products').with({ 'proxy_password' => 'password' }) }
+        end
+      end
     end
   end
 end

--- a/spec/classes/puppetserver__repository_spec.rb
+++ b/spec/classes/puppetserver__repository_spec.rb
@@ -15,31 +15,37 @@ describe 'puppetserver::repository' do
 
       case facts[:osfamily]
       when 'RedHat'
-        context 'on redhat without proxy parameters set' do
+        context 'on redhat without parameters set' do
           it { should contain_yumrepo('puppetlabs-deps').without_proxy }
           it { should contain_yumrepo('puppetlabs-deps').without_proxy_username }
           it { should contain_yumrepo('puppetlabs-deps').without_proxy_password }
+          it { should contain_yumrepo('puppetlabs-deps').with_baseurl(/yum.puppetlabs.com/) }
 
           it { should contain_yumrepo('puppetlabs-products').without_proxy }
           it { should contain_yumrepo('puppetlabs-products').without_proxy_username }
           it { should contain_yumrepo('puppetlabs-products').without_proxy_password }
+          it { should contain_yumrepo('puppetlabs-products').with_baseurl(/yum.puppetlabs.com/) }
         end
 
-        context 'on redhat with proxy parameters set' do
+        context 'on redhat with parameters set' do
           let(:params) do
             {
-              :yum_proxy => 'http://proxy:8080/',
-              :yum_proxy_username => 'user',
-              :yum_proxy_password => 'password',
+              :yum_proxy            => 'http://proxy:8080/',
+              :yum_proxy_username   => 'user',
+              :yum_proxy_password   => 'password',
+              :yum_deps_baseurl     => 'http://yum.internal/deps/',
+              :yum_products_baseurl => 'http://yum.internal/products/',
             }
           end
           it { should contain_yumrepo('puppetlabs-deps').with({ 'proxy' => 'http://proxy:8080/' }) }
           it { should contain_yumrepo('puppetlabs-deps').with({ 'proxy_username' => 'user' }) }
           it { should contain_yumrepo('puppetlabs-deps').with({ 'proxy_password' => 'password' }) }
+          it { should contain_yumrepo('puppetlabs-deps').with_baseurl(/yum.internal/) }
 
           it { should contain_yumrepo('puppetlabs-products').with({ 'proxy' => 'http://proxy:8080/' }) }
           it { should contain_yumrepo('puppetlabs-products').with({ 'proxy_username' => 'user' }) }
           it { should contain_yumrepo('puppetlabs-products').with({ 'proxy_password' => 'password' }) }
+          it { should contain_yumrepo('puppetlabs-products').with_baseurl(/yum.internal/) }
         end
       end
     end


### PR DESCRIPTION
we are using an internal mirror of the puppetlabs repo which is only accessible via a proxy. so this pull requests adds support for specifing

- yum proxy url
- yum proxy username
- yum proxy password
- baseurl for the dependencies repo
- baseurl for the products repo

and the corresponding rspec tests.

the defaults did not change, so existing installations are not affected by this change.