### PR TITLE
Allow simple entries as standalones

### DIFF
--- a/files/lenses/trapperkeeper.aug
+++ b/files/lenses/trapperkeeper.aug
@@ -31,7 +31,7 @@ let empty = Util.empty
 let comment = Util.comment
 
 (* View: sep *)
-let sep = del /[ \t]*[:=]/ ":"
+let sep = del /[ \t]*[\/:=]/ ":"
 
 (* View: sep_with_spc *)
 let sep_with_spc = sep . Sep.opt_space
@@ -75,7 +75,7 @@ let block_newlines (entry:lens) (comment:lens) =
 let opt_dquot (lns:lens) = del /"?/ "" . lns . del /"?/ ""
 
 (* View: simple *)
-let simple = [ Util.indent . label "@simple" . opt_dquot (store /[A-Za-z0-9_.\/-]+/) . sep_with_spc
+let simple = [ Util.indent . label "@simple" . opt_dquot (store /[A-Za-z0-9_.-]+/) . sep_with_spc
              . [ label "@value" . opt_dquot (store /[^,"\[ \t\n]+/) ]
              . Util.eol ]
 
@@ -103,17 +103,22 @@ let hash (lns:lens) = [ Util.indent . label "@hash" . store Rx.word . sep
  *************************************************************************)
 
 (* Just for typechecking *)
-let entry_no_rec = hash (simple|array)
+let entry_hash_no_rec = hash (simple|array)
 
-(* View: entry *)
-let rec entry = hash (entry|simple|array)
+let entry_simple_no_rec = simple
+
+(* View: entry_hash *)
+let rec entry_hash = hash (entry_hash|simple|array)
+
+(* View: entry_simple *)
+let rec entry_simple = simple
 
 (************************************************************************
  * Group:                LENS AND FILTER
  *************************************************************************)
 
 (* View: lns *)
-let lns = (empty|comment)* . (entry . (empty|comment)*)*
+let lns = (empty|comment)* . ((entry_hash|entry_simple) . (empty|comment)*)*
 
 (* Variable: filter *)
 let filter = incl "/etc/puppetserver/conf.d/*"


### PR DESCRIPTION
Tagging @raphink for visibility.

While working on https://github.com/theforeman/puppet-puppet/pull/343 I ran into a problem where I couldn't match bootstrap.cfg:

```shell
% cat bootstrap.cfg
puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
puppetlabs.services.request-handler.request-handler-service/request-handler-service
puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
puppetlabs.services.master.master-service/master-service
puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
puppetlabs.services.version.version-check-service/version-check-service
puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
```

This PR adjusts it so that you can have just simple entries without a wrapping hash, as well as allowing '/' as a separator.

```shell
% cat test.augeas 
#!/usr/local/bin/augtool -f -n -L -A
set /augeas/load/Trapperkeeper/lens trapperkeeper.lns
set /augeas/load/Trapperkeeper/incl /Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/*.c*
load
ls /files/Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/bootstrap.cfg
ls /files/Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/global.conf
print /files/Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/global.conf
save
quit

% augtool -L -A -f test.augeas
@simple[1]/ = puppetlabs.services.jruby.jruby-puppet-service
@simple[2]/ = puppetlabs.services.puppet-profiler.puppet-profiler-service
@simple[3]/ = puppetlabs.trapperkeeper.services.webserver.jetty9-service
@simple[4]/ = puppetlabs.trapperkeeper.services.webrouting.webrouting-service
@simple[5]/ = puppetlabs.services.request-handler.request-handler-service
@simple[6]/ = puppetlabs.services.config.puppet-server-config-service
@simple[7]/ = puppetlabs.services.master.master-service
@simple[8]/ = puppetlabs.services.puppet-admin.puppet-admin-service
@simple[9]/ = puppetlabs.services.version.version-check-service
@simple[10]/ = puppetlabs.services.ca.certificate-authority-disabled-service
@hash/ = global
/files/Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/global.conf
/files/Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/global.conf/@hash = "global"
/files/Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/global.conf/@hash/#comment[1] = "Path to logback logging configuration file; for more"
/files/Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/global.conf/@hash/#comment[2] = "info, see http://logback.qos.ch/manual/configuration.html"
/files/Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/global.conf/@hash/@simple = "logging-config"
/files/Users/joseph.yaworski/github/puppet-puppet/templates/server/puppetserver/global.conf/@hash/@simple/@value = "/etc/puppetlabs/puppetserver/logback.xml"