### PR TITLE
Remove hardcoded version for hiera-eyaml-gpg

### DIFF
--- a/manifests/hiera/eyaml.pp
+++ b/manifests/hiera/eyaml.pp
@@ -14,9 +14,7 @@ class puppetserver::hiera::eyaml (
 
     'gpg': {
       package { 'ruby_gpg': } ->
-      package { 'hiera-eyaml-gpg':
-        ensure => '0.5.rc1',
-      }
+      package { 'hiera-eyaml-gpg': }
     }
 
     default: {


### PR DESCRIPTION
As hiera-eyaml-gpg is now at version 0.6, incorporating the
changes for making it work without the native extensions (gpgme),
there is no need to pin the package to version 0.5rc1 anymore.