### PR TITLE
Add parameter for specifying which APT repo to use

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -4,7 +4,8 @@ class puppetserver::repository (
   $yum_proxy_password   = undef,
   $yum_deps_baseurl     = undef,
   $yum_products_baseurl = undef,
-  ){
+  $apt_repo             = 'puppet',
+) {
 
 
   if $yum_deps_baseurl {
@@ -26,7 +27,7 @@ class puppetserver::repository (
       include ::apt
       apt::source { 'puppetlabs':
         location => 'http://apt.puppetlabs.com',
-        repos    => 'main',
+        repos    => $apt_repo,
         key      => {
             id     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
             server => 'pool.sks-keyservers.net',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds a parameter to ``puppetserver::repository`` for specifying which APT repo to use. Defaults to ``puppet`` which contains the latest major release.

#### This Pull Request (PR) fixes the following issues
Fixes #67 