### PR TITLE
ReservedCodeCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ class { 'puppetserver': }
 class { 'puppetserver::repository': } ->
 class { 'puppetserver':
   config => {
-    'java_args'     => {
-      'xms'         => '4g',
-      'xmx'         => '6g',
-      'maxpermsize' => '512m',
-      'tmpdir'      => '/tmp',
+    'java_args'               => {
+      'xms'                   => '4g',
+      'xmx'                   => '6g',
+      'maxpermsize'           => '512m',
+      'reservedcodecachesize' => '512m',
+      'tmpdir'                => '/tmp',
     },
 
     'webserver'  => {
@@ -131,7 +132,7 @@ gem { 'hiera-eyaml':
   provider => puppetserver_gem,
 }
 ```
- 
+
 ## Contributing
 
 Please report bugs and feature request using [GitHub issue
@@ -140,7 +141,7 @@ tracker](https://github.com/camptocamp/puppet-puppetserver/issues).
 For pull requests, it is very much appreciated to check your Puppet manifest
 with [puppet-lint](http://puppet-lint.com/) to follow the recommended Puppet style guidelines from the
 [Puppet Labs style guide](http://docs.puppetlabs.com/guides/style_guide.html).
- 
+
 
 ## Transfer Notice
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,6 +20,11 @@ class puppetserver::config {
       type    => 'java_arg',
       ;
 
+    'java_args/reservedcodecachesize':
+      setting => '-XX:ReservedCodeCacheSize=',
+      type    => 'java_arg',
+      ;
+
     'webserver/port':
       setting => 'webserver.conf/webserver/port',
       type    => 'puppetserver',


### PR DESCRIPTION
#### Pull Request (PR) description
During some performance tuning we had to set the ReservedCodeCacheSize of Java. This allows to increase the Reserved code cache size (in bytes).
This is described in the [Puppetserver performance tuning guide](https://puppet.com/docs/puppetserver/latest/tuning_guide.html#potential-java-args-settings), but in Oracle Java SE 8 the parameter is called ReservedCodeCacheSize (see [Codecache documentation](https://docs.oracle.com/javase/8/embedded/develop-apps-platforms/codecache.htm)).

#### This Pull Request (PR) fixes the following issues
n/a